### PR TITLE
Navigation in MainActivity fix

### DIFF
--- a/app/src/androidTest/java/com/android/feedme/screen/CreateScreen.kt
+++ b/app/src/androidTest/java/com/android/feedme/screen/CreateScreen.kt
@@ -1,0 +1,16 @@
+package com.android.feedme.screen
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+/** This class represents the Create Screen and the elements it contains. */
+class CreateScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CreateScreen>(
+        semanticsProvider = semanticsProvider, viewBuilderAction = { hasTestTag("CreateScreen") }) {
+
+  // Structural elements of the UI
+  val topBarLanding: KNode = child { hasTestTag("TopBarNavigation") }
+  val bottomBarLanding: KNode = child { hasTestTag("BottomNavigationMenu") }
+  val cameraButton: KNode = child { hasTestTag("CameraButton") }
+}

--- a/app/src/androidTest/java/com/android/feedme/screen/NotImplementedScreen.kt
+++ b/app/src/androidTest/java/com/android/feedme/screen/NotImplementedScreen.kt
@@ -1,0 +1,17 @@
+package com.android.feedme.screen
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+/** This class represents the Landing Screen and the elements it contains. */
+class NotImplementedScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<NotImplementedScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("NotImplementedScreen") }) {
+
+  // Structural elements of the UI
+  val topBarLanding: KNode = child { hasTestTag("TopBarNavigation") }
+  val bottomBarLanding: KNode = child { hasTestTag("BottomNavigationMenu") }
+  val middleText: KNode = child { hasTestTag("Text") }
+}

--- a/app/src/androidTest/java/com/android/feedme/test/CreateTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/CreateTest.kt
@@ -1,0 +1,72 @@
+package com.android.feedme.test
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.feedme.screen.CreateScreen
+import com.android.feedme.ui.CreateScreen
+import com.android.feedme.ui.navigation.NavigationActions
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreateTest : TestCase() {
+  // @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
+
+  // The IntentsTestRule simply calls Intents.init() before the @Test block
+  // and Intents.release() after the @Test block is completed. IntentsTestRule
+  // is deprecated, but it was MUCH faster than using IntentsRule in our tests
+  // @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java) TODO: Fix testing
+  // with navigation
+
+  /*@Before
+  fun setup() {
+  TODO: Fix testing with navigation
+
+   System.setProperty("isRunningTest", "true")
+   val mockGoogleSignInClient = mockk<GoogleSignInClient>(relaxed = true)
+   MockServiceLocator.registerService("GoogleSignInClient", mockGoogleSignInClient)
+   val mockGoogleSignInAccount = mockk<GoogleSignInAccount>(relaxed = true)
+   every { mockGoogleSignInClient.silentSignIn() } returns Tasks.forResult(mockGoogleSignInAccount)
+
+    }*/
+
+  @Test
+  fun mainComponentsAreDisplayed() {
+    goToCreateScreen()
+
+    ComposeScreen.onComposeScreen<CreateScreen>(composeTestRule) {
+      topBarLanding { assertIsDisplayed() }
+
+      bottomBarLanding { assertIsDisplayed() }
+
+      cameraButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+    }
+  }
+
+  private fun goToCreateScreen() {
+    composeTestRule.setContent { CreateScreen(mockk<NavigationActions>()) }
+    composeTestRule.waitForIdle()
+
+    // TODO: Fix testing with navigation
+    /*// This function is used to navigate from LoginScreen to LandingScreen
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      loginButton {
+        performClick()
+      }
+      composeTestRule.waitForIdle()
+
+      // Assert that the Google SignIn Client was called
+      //verify { mockGoogleSignInClient.silentSignIn() }
+
+      composeTestRule.waitForIdle()
+    }*/
+  }
+}

--- a/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
@@ -1,36 +1,44 @@
 package com.android.feedme.test
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.feedme.CurrentScreen
-import com.android.feedme.MainActivity
 import com.android.feedme.screen.LandingScreen
+import com.android.feedme.ui.LandingPage
+import com.android.feedme.ui.navigation.NavigationActions
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import org.junit.Before
+import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class LandingTest : TestCase() {
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  // @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
 
   // The IntentsTestRule simply calls Intents.init() before the @Test block
   // and Intents.release() after the @Test block is completed. IntentsTestRule
   // is deprecated, but it was MUCH faster than using IntentsRule in our tests
-  @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+  // @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java) TODO: Fix testing
+  // with navigation
 
-  @Before
+  /*@Before
   fun setup() {
-    val scenario = ActivityScenario.launch(MainActivity::class.java)
-    scenario.onActivity { activity -> activity.setScreen(CurrentScreen.LANDING) }
-  }
+  TODO: Fix testing with navigation
+
+   System.setProperty("isRunningTest", "true")
+   val mockGoogleSignInClient = mockk<GoogleSignInClient>(relaxed = true)
+   MockServiceLocator.registerService("GoogleSignInClient", mockGoogleSignInClient)
+   val mockGoogleSignInAccount = mockk<GoogleSignInAccount>(relaxed = true)
+   every { mockGoogleSignInClient.silentSignIn() } returns Tasks.forResult(mockGoogleSignInAccount)
+
+    }*/
 
   @Test
   fun mainComponentsAreDisplayed() {
+    goToLandingScreen()
+
     ComposeScreen.onComposeScreen<LandingScreen>(composeTestRule) {
       topBarLanding { assertIsDisplayed() }
 
@@ -53,5 +61,24 @@ class LandingTest : TestCase() {
         assertHasClickAction()
       }
     }
+  }
+
+  private fun goToLandingScreen() {
+    composeTestRule.setContent { LandingPage(mockk<NavigationActions>()) }
+    composeTestRule.waitForIdle()
+
+    // TODO: Fix testing with navigation
+    /*// This function is used to navigate from LoginScreen to LandingScreen
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      loginButton {
+        performClick()
+      }
+      composeTestRule.waitForIdle()
+
+      // Assert that the Google SignIn Client was called
+      //verify { mockGoogleSignInClient.silentSignIn() }
+
+      composeTestRule.waitForIdle()
+    }*/
   }
 }

--- a/app/src/androidTest/java/com/android/feedme/test/NotImplementedTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/NotImplementedTest.kt
@@ -1,0 +1,70 @@
+package com.android.feedme.test
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.feedme.screen.NotImplementedScreen
+import com.android.feedme.ui.NotImplementedScreen
+import com.android.feedme.ui.navigation.NavigationActions
+import com.android.feedme.ui.navigation.Route
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NotImplementedTest : TestCase() {
+  // @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
+
+  // The IntentsTestRule simply calls Intents.init() before the @Test block
+  // and Intents.release() after the @Test block is completed. IntentsTestRule
+  // is deprecated, but it was MUCH faster than using IntentsRule in our tests
+  // @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java) TODO: Fix testing
+  // with navigation
+
+  /*@Before
+  fun setup() {
+  TODO: Fix testing with navigation
+
+   System.setProperty("isRunningTest", "true")
+   val mockGoogleSignInClient = mockk<GoogleSignInClient>(relaxed = true)
+   MockServiceLocator.registerService("GoogleSignInClient", mockGoogleSignInClient)
+   val mockGoogleSignInAccount = mockk<GoogleSignInAccount>(relaxed = true)
+   every { mockGoogleSignInClient.silentSignIn() } returns Tasks.forResult(mockGoogleSignInAccount)
+
+    }*/
+
+  @Test
+  fun mainComponentsAreDisplayed() {
+    goToCreateScreen()
+
+    ComposeScreen.onComposeScreen<NotImplementedScreen>(composeTestRule) {
+      topBarLanding { assertIsDisplayed() }
+
+      bottomBarLanding { assertIsDisplayed() }
+
+      middleText { assertIsDisplayed() }
+    }
+  }
+
+  private fun goToCreateScreen() {
+    composeTestRule.setContent { NotImplementedScreen(mockk<NavigationActions>(), Route.SETTINGS) }
+    composeTestRule.waitForIdle()
+
+    // TODO: Fix testing with navigation
+    /*// This function is used to navigate from LoginScreen to LandingScreen
+    ComposeScreen.onComposeScreen<LoginScreen>(composeTestRule) {
+      loginButton {
+        performClick()
+      }
+      composeTestRule.waitForIdle()
+
+      // Assert that the Google SignIn Client was called
+      //verify { mockGoogleSignInClient.silentSignIn() }
+
+      composeTestRule.waitForIdle()
+    }*/
+  }
+}

--- a/app/src/androidTest/java/com/android/feedme/test/ProfileTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/ProfileTest.kt
@@ -1,33 +1,27 @@
 package com.android.feedme.test
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.feedme.CurrentScreen
-import com.android.feedme.MainActivity
 import com.android.feedme.screen.ProfileScreen
+import com.android.feedme.ui.ProfileScreen
+import com.android.feedme.ui.navigation.NavigationActions
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import org.junit.Before
+import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ProfileTest {
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
-  @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+  // @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
 
-  @Before
-  fun setup() {
-    val scenario = ActivityScenario.launch(MainActivity::class.java)
-    scenario.onActivity { activity ->
-      activity.setScreen(CurrentScreen.PROFILE) // For ProfileTest
-    }
-  }
+  // @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java) TODO: Fix testing
+  // with navigation
 
   @Test
   fun profileBoxAndComponentsCorrectlyDisplayed() {
+    goToProfileScreen()
     ComposeScreen.onComposeScreen<ProfileScreen>(composeTestRule) {
       topBarProfile { assertIsDisplayed() }
 
@@ -61,5 +55,10 @@ class ProfileTest {
         assertHasClickAction()
       }
     }
+  }
+
+  private fun goToProfileScreen() {
+    composeTestRule.setContent { ProfileScreen(mockk<NavigationActions>()) }
+    composeTestRule.waitForIdle()
   }
 }

--- a/app/src/androidTest/java/com/android/feedme/test/auth/LoginTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/auth/LoginTest.kt
@@ -1,17 +1,14 @@
 package com.android.feedme.test.auth
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.feedme.CurrentScreen
 import com.android.feedme.MainActivity
 import com.android.feedme.screen.LoginScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,12 +21,6 @@ class LoginTest : TestCase() {
   // and Intents.release() after the @Test block is completed. IntentsTestRule
   // is deprecated, but it was MUCH faster than using IntentsRule in our tests
   @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java)
-
-  @Before
-  fun setup() {
-    val scenario = ActivityScenario.launch(MainActivity::class.java)
-    scenario.onActivity { activity -> activity.setScreen(CurrentScreen.LOGIN) }
-  }
 
   @Test
   fun titleAndButtonAreCorrectlyDisplayed() {

--- a/app/src/androidTest/java/com/android/feedme/test/camera/CameraTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/camera/CameraTest.kt
@@ -2,42 +2,38 @@ package com.android.feedme.test.camera
 
 import android.Manifest
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
-import com.android.feedme.CurrentScreen
-import com.android.feedme.MainActivity
 import com.android.feedme.screen.CameraScreen
+import com.android.feedme.ui.camera.CameraScreen
+import com.android.feedme.ui.navigation.NavigationActions
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import org.junit.Before
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class CameraTest : TestCase() {
-  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
-  @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+  // @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createComposeRule()
+
+  // @get:Rule val intentsTestRule = IntentsTestRule(MainActivity::class.java) TODO: Fix testing
+  // with navigation
 
   // Grant camera permission for tests
   @get:Rule
   val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
 
-  @Before
-  fun setup() {
-    val scenario = ActivityScenario.launch(MainActivity::class.java)
-    scenario.onActivity { activity ->
-      activity.setScreen(CurrentScreen.CAMERA) // For CameraTest
-    }
-  }
-
   @Test
   fun buttonsAndCameraCorrectlyDisplayed() {
+    goToCameraScreen()
+
     ComposeScreen.onComposeScreen<CameraScreen>(composeTestRule) {
       cameraPreview { assertIsDisplayed() }
 
@@ -54,6 +50,8 @@ class CameraTest : TestCase() {
 
   @Test
   fun galleryButtonDisplayGalleryWhenEmpty() {
+    goToCameraScreen()
+
     ComposeScreen.onComposeScreen<CameraScreen>(composeTestRule) {
       cameraPreview { assertIsDisplayed() }
 
@@ -76,6 +74,8 @@ class CameraTest : TestCase() {
 
   @Test
   fun galleryButtonDisplayGalleryAfterTakingPhoto() {
+    goToCameraScreen()
+
     ComposeScreen.onComposeScreen<CameraScreen>(composeTestRule) {
       cameraPreview { assertIsDisplayed() }
 
@@ -107,5 +107,12 @@ class CameraTest : TestCase() {
           .onNodeWithContentDescription("Photo", useUnmergedTree = true)
           .assertIsDisplayed()
     }
+  }
+
+  private fun goToCameraScreen() {
+    val navActions = mockk<NavigationActions>()
+    every { navActions.canGoBack() } returns true
+    composeTestRule.setContent { CameraScreen(navActions) }
+    composeTestRule.waitForIdle()
   }
 }

--- a/app/src/androidTest/java/com/android/feedme/test/component/SmallThumbnailsDisplayTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/component/SmallThumbnailsDisplayTest.kt
@@ -6,12 +6,12 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.feedme.SmallThumbnailsDisplay
 import com.android.feedme.model.data.Ingredient
 import com.android.feedme.model.data.IngredientMetaData
 import com.android.feedme.model.data.MeasureUnit
 import com.android.feedme.model.data.Recipe
 import com.android.feedme.model.data.Step
+import com.android.feedme.ui.component.SmallThumbnailsDisplay
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/main/java/com/android/feedme/MainActivity.kt
+++ b/app/src/main/java/com/android/feedme/MainActivity.kt
@@ -17,7 +17,7 @@ import androidx.navigation.compose.rememberNavController
 import com.android.feedme.model.data.ProfileRepository
 import com.android.feedme.model.data.RecipeRepository
 import com.android.feedme.resources.C
-import com.android.feedme.ui.CreateSceen
+import com.android.feedme.ui.CreateScreen
 import com.android.feedme.ui.LandingPage
 import com.android.feedme.ui.NotImplementedScreen
 import com.android.feedme.ui.ProfileScreen
@@ -51,7 +51,7 @@ class MainActivity : ComponentActivity() {
                 composable(Route.AUTHENTICATION) { LoginScreen(navigationActions) }
                 composable(Route.HOME) { LandingPage(navigationActions) }
                 composable(Route.EXPLORE) { NotImplementedScreen(navigationActions, Route.EXPLORE) }
-                composable(Route.CREATE) { CreateSceen(navigationActions) }
+                composable(Route.CREATE) { CreateScreen(navigationActions) }
                 composable(Route.PROFILE) { ProfileScreen(navigationActions) }
                 composable(Route.SETTINGS) {
                   NotImplementedScreen(navigationActions, Route.SETTINGS)

--- a/app/src/main/java/com/android/feedme/MainActivity.kt
+++ b/app/src/main/java/com/android/feedme/MainActivity.kt
@@ -7,39 +7,32 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.android.feedme.model.data.ProfileRepository
 import com.android.feedme.model.data.RecipeRepository
 import com.android.feedme.resources.C
+import com.android.feedme.ui.CreateSceen
 import com.android.feedme.ui.LandingPage
+import com.android.feedme.ui.NotImplementedScreen
+import com.android.feedme.ui.ProfileScreen
 import com.android.feedme.ui.auth.LoginScreen
 import com.android.feedme.ui.camera.CameraScreen
 import com.android.feedme.ui.navigation.NavigationActions
-import com.android.feedme.ui.profile.ProfileScreen
+import com.android.feedme.ui.navigation.Route
 import com.android.feedme.ui.theme.feedmeAppTheme
 import com.google.firebase.firestore.FirebaseFirestore
 
 class MainActivity : ComponentActivity() {
-  /**
-   * currentScreen and setScreen are used for testing, this is temporary since we still aren't
-   * testing Navigation
-   */
-  // Use mutableStateOf for the currentScreen. Initialize with LOGIN.
-  var currentScreen by mutableStateOf(CurrentScreen.LOGIN)
-    private set // Make the setter private to control state changes from outside
-
-  // Public method to change the screen, ensuring recomposition
-  fun setScreen(screen: CurrentScreen) {
-    currentScreen = screen
-  }
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    // Initialize Firebase
     val firebase = FirebaseFirestore.getInstance()
     ProfileRepository.initialize(firebase)
     RecipeRepository.initialize(firebase)
@@ -49,23 +42,24 @@ class MainActivity : ComponentActivity() {
         Surface(
             modifier = Modifier.fillMaxSize().semantics { testTag = C.Tag.main_screen_container },
             color = MaterialTheme.colorScheme.background) {
+              // Navigation host for the app
               val navController = rememberNavController()
               val navigationActions = NavigationActions(navController)
-              when (currentScreen) {
-                CurrentScreen.LOGIN -> LoginScreen()
-                CurrentScreen.CAMERA -> CameraScreen()
-                CurrentScreen.LANDING -> LandingPage(navigationActions)
-                CurrentScreen.PROFILE -> ProfileScreen(navigationActions)
+
+              // Set up the navigation graph
+              NavHost(navController = navController, startDestination = Route.AUTHENTICATION) {
+                composable(Route.AUTHENTICATION) { LoginScreen(navigationActions) }
+                composable(Route.HOME) { LandingPage(navigationActions) }
+                composable(Route.EXPLORE) { NotImplementedScreen(navigationActions, Route.EXPLORE) }
+                composable(Route.CREATE) { CreateSceen(navigationActions) }
+                composable(Route.PROFILE) { ProfileScreen(navigationActions) }
+                composable(Route.SETTINGS) {
+                  NotImplementedScreen(navigationActions, Route.SETTINGS)
+                }
+                composable(Route.CAMERA) { CameraScreen(navigationActions) }
               }
             }
       }
     }
   }
-}
-
-enum class CurrentScreen {
-  LOGIN,
-  CAMERA,
-  LANDING,
-  PROFILE
 }

--- a/app/src/main/java/com/android/feedme/resources/mock/MockServiceLocator.kt
+++ b/app/src/main/java/com/android/feedme/resources/mock/MockServiceLocator.kt
@@ -1,5 +1,8 @@
 package com.android.feedme.resources.mock
 
+/*
+TODO: May be useful to implement this class when fixing the tests with navigation
+
 object MockServiceLocator {
   private val services = mutableMapOf<String, Any>()
 
@@ -11,4 +14,4 @@ object MockServiceLocator {
   fun <T> getService(key: String): T {
     return services[key] as T
   }
-}
+}*/

--- a/app/src/main/java/com/android/feedme/resources/mock/MockServiceLocator.kt
+++ b/app/src/main/java/com/android/feedme/resources/mock/MockServiceLocator.kt
@@ -1,0 +1,14 @@
+package com.android.feedme.resources.mock
+
+object MockServiceLocator {
+  private val services = mutableMapOf<String, Any>()
+
+  fun <T : Any> registerService(key: String, service: T) {
+    services[key] = service
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T> getService(key: String): T {
+    return services[key] as T
+  }
+}

--- a/app/src/main/java/com/android/feedme/ui/CreateScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/CreateScreen.kt
@@ -1,0 +1,42 @@
+package com.android.feedme.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.android.feedme.ui.navigation.BottomNavigationMenu
+import com.android.feedme.ui.navigation.NavigationActions
+import com.android.feedme.ui.navigation.Route
+import com.android.feedme.ui.navigation.TOP_LEVEL_DESTINATIONS
+import com.android.feedme.ui.navigation.TopBarNavigation
+
+/** Composable function that */
+@Composable
+fun CreateSceen(navigationActions: NavigationActions) {
+
+  Scaffold(
+      topBar = { TopBarNavigation(title = "Create", navAction = null) },
+      bottomBar = {
+        BottomNavigationMenu(
+            selectedItem = Route.CREATE,
+            onTabSelect = navigationActions::navigateTo,
+            tabList = TOP_LEVEL_DESTINATIONS)
+      },
+      content = { paddingValues ->
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+              OutlinedButton(
+                  modifier = Modifier.padding(20.dp),
+                  onClick = { navigationActions.navigateTo(Route.CAMERA) }) {
+                    Text(text = "Camera")
+                  }
+            }
+      })
+}

--- a/app/src/main/java/com/android/feedme/ui/CreateScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/CreateScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.feedme.ui.navigation.BottomNavigationMenu
 import com.android.feedme.ui.navigation.NavigationActions
@@ -18,9 +19,10 @@ import com.android.feedme.ui.navigation.TopBarNavigation
 
 /** Composable function that */
 @Composable
-fun CreateSceen(navigationActions: NavigationActions) {
+fun CreateScreen(navigationActions: NavigationActions) {
 
   Scaffold(
+      modifier = Modifier.testTag("CreateScreen"),
       topBar = { TopBarNavigation(title = "Create", navAction = null) },
       bottomBar = {
         BottomNavigationMenu(
@@ -33,7 +35,7 @@ fun CreateSceen(navigationActions: NavigationActions) {
             contentAlignment = Alignment.Center,
             modifier = Modifier.fillMaxSize().padding(paddingValues)) {
               OutlinedButton(
-                  modifier = Modifier.padding(20.dp),
+                  modifier = Modifier.padding(20.dp).testTag("CameraButton"),
                   onClick = { navigationActions.navigateTo(Route.CAMERA) }) {
                     Text(text = "Camera")
                   }

--- a/app/src/main/java/com/android/feedme/ui/LandingScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/LandingScreen.kt
@@ -46,7 +46,7 @@ import com.android.feedme.ui.theme.TextBarColor
 /**
  * Composable function that generates the landing page
  *
- * @param navigationActions : the nav actions given in the MainActivity
+ * @param navigationActions The navigation actions instance for handling back navigation.
  */
 @Composable
 fun LandingPage(navigationActions: NavigationActions) {

--- a/app/src/main/java/com/android/feedme/ui/NotImplementedScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/NotImplementedScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.feedme.ui.navigation.BottomNavigationMenu
 import com.android.feedme.ui.navigation.NavigationActions
@@ -23,6 +24,7 @@ import com.android.feedme.ui.navigation.TopBarNavigation
 fun NotImplementedScreen(navigationActions: NavigationActions, selectedItem: String) {
 
   Scaffold(
+      modifier = Modifier.testTag("NotImplementedScreen"),
       topBar = { TopBarNavigation(title = "Not Implemented", navAction = null) },
       bottomBar = {
         BottomNavigationMenu(
@@ -36,7 +38,7 @@ fun NotImplementedScreen(navigationActions: NavigationActions, selectedItem: Str
             modifier = Modifier.fillMaxSize().padding(paddingValues)) {
               Text(
                   text = "This feature is not implemented yet. Please check back later.",
-                  modifier = Modifier.padding(20.dp))
+                  modifier = Modifier.padding(20.dp).testTag("Text"))
             }
       })
 }

--- a/app/src/main/java/com/android/feedme/ui/NotImplementedScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/NotImplementedScreen.kt
@@ -1,0 +1,42 @@
+package com.android.feedme.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.android.feedme.ui.navigation.BottomNavigationMenu
+import com.android.feedme.ui.navigation.NavigationActions
+import com.android.feedme.ui.navigation.TOP_LEVEL_DESTINATIONS
+import com.android.feedme.ui.navigation.TopBarNavigation
+
+/**
+ * Screen that is displayed when a feature is not implemented.
+ *
+ * @param navigationActions The navigation actions instance for handling back navigation.
+ */
+@Composable
+fun NotImplementedScreen(navigationActions: NavigationActions, selectedItem: String) {
+
+  Scaffold(
+      topBar = { TopBarNavigation(title = "Not Implemented", navAction = null) },
+      bottomBar = {
+        BottomNavigationMenu(
+            selectedItem = selectedItem,
+            onTabSelect = navigationActions::navigateTo,
+            tabList = TOP_LEVEL_DESTINATIONS)
+      },
+      content = { paddingValues ->
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+              Text(
+                  text = "This feature is not implemented yet. Please check back later.",
+                  modifier = Modifier.padding(20.dp))
+            }
+      })
+}

--- a/app/src/main/java/com/android/feedme/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/ProfileScreen.kt
@@ -1,4 +1,4 @@
-package com.android.feedme.ui.profile
+package com.android.feedme.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -41,6 +41,8 @@ import com.android.feedme.ui.theme.DarkGrey
  *
  * This function provides the UI interface of the profile page, which includes the profile box,
  * recipe page of the user and the comments of the user.
+ *
+ * @param navigationActions The navigation actions instance for handling back navigation.
  */
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {

--- a/app/src/main/java/com/android/feedme/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/auth/LoginScreen.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.feedme.R
+import com.android.feedme.ui.navigation.NavigationActions
+import com.android.feedme.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -54,11 +56,11 @@ import kotlinx.coroutines.tasks.await
  *
  * This function provides a UI for users to sign in with Google authentication. It includes a Google
  * sign-in button and handles authentication flow using Firebase authentication.
+ *
+ * @param navigationActions : the nav actions given in the MainActivity
  */
 @Composable
-fun LoginScreen() { // TODO : Add an argument for the navigation as in bootcamp : navAction:
-  // NavigationActions
-
+fun LoginScreen(navigationActions: NavigationActions) {
   // TODO Make sure that there are no sign-in user
   // Firebase.auth.signOut() this line doesn't work.
 
@@ -70,6 +72,14 @@ fun LoginScreen() { // TODO : Add an argument for the navigation as in bootcamp 
           .requestEmail()
           .build()
   val googleSignInClient = GoogleSignIn.getClient(context, gso)
+  /*val googleSignInClient =
+     if (BuildConfig.DEBUG) {
+       MockServiceLocator.getService("GoogleSignInClient")
+     } else {
+       GoogleSignIn.getClient(context, gso)
+     }
+     TODO: Fix navigated testing
+  */
 
   /**
    * Remember Firebase authentication launcher.
@@ -110,7 +120,8 @@ fun LoginScreen() { // TODO : Add an argument for the navigation as in bootcamp 
       rememberFirebaseAuthLauncher(
           onAuthComplete = { _ ->
             Log.d("LOGIN", "Login was successful")
-            // TODO ADD NAVIGATION HERE
+            // Navigate to the first tab,
+            navigationActions.navigateTo(TOP_LEVEL_DESTINATIONS[0])
           },
           onAuthError = { e -> Log.d("LOGIN", "Login failed", e) })
   Column(

--- a/app/src/main/java/com/android/feedme/ui/camera/Camera.kt
+++ b/app/src/main/java/com/android/feedme/ui/camera/Camera.kt
@@ -54,6 +54,8 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.feedme.model.CameraViewModel
+import com.android.feedme.ui.navigation.NavigationActions
+import com.android.feedme.ui.navigation.TopBarNavigation
 import kotlinx.coroutines.launch
 
 /**
@@ -66,7 +68,7 @@ import kotlinx.coroutines.launch
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CameraScreen() {
+fun CameraScreen(navigationActions: NavigationActions) {
   val applicationContext = LocalContext.current
 
   // Request camera permission if not already granted
@@ -89,6 +91,7 @@ fun CameraScreen() {
 
   BottomSheetScaffold(
       modifier = Modifier.testTag("CameraScreen"),
+      topBar = { TopBarNavigation(title = "Camera", navigationActions, null) },
       scaffoldState = scaffoldState,
       sheetPeekHeight = 0.dp,
       sheetContent = {

--- a/app/src/main/java/com/android/feedme/ui/component/SmallTumbnailsDisplay.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/SmallTumbnailsDisplay.kt
@@ -1,4 +1,4 @@
-package com.android.feedme
+package com.android.feedme.ui.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/java/com/android/feedme/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/feedme/ui/navigation/NavigationActions.kt
@@ -24,7 +24,7 @@ class NavigationActions(private val navController: NavHostController) {
   /**
    * Navigates to the specified [TopLevelDestination] destination.
    *
-   * @param destination The destination to navigate to.
+   * @param destination The top level destination to navigate to.
    */
   fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
@@ -38,6 +38,16 @@ class NavigationActions(private val navController: NavHostController) {
       // Restore state when reselecting a previously selected item
       restoreState = true
     }
+  }
+
+  /**
+   * Navigates to the specified route.
+   *
+   * @param route The route to navigate to.
+   */
+  fun navigateTo(route: String) {
+    // When calling this method, the back bottom would be available to go back using goBack()
+    navController.navigate(route)
   }
 
   /** Navigates back to the previous destination in the navigation stack. */
@@ -58,11 +68,13 @@ class NavigationActions(private val navController: NavHostController) {
 
 /** Contains route constants used for navigating within the app. */
 object Route {
+  const val AUTHENTICATION = "Authentication"
   const val HOME = "Home"
   const val EXPLORE = "Explore"
   const val CREATE = "Create"
   const val PROFILE = "Profile"
   const val SETTINGS = "Settings"
+  const val CAMERA = "Camera"
 }
 
 /**


### PR DESCRIPTION
Fixing the navigation when running the app module.
Modifying the testing for LoginScreen, ProfileScreen, LandingPage and CameraScreen since it was dependent on a temporary MainActivity.kt that has now changed.