### PR TITLE
Create End-to-end Userflow Test (HomePage -> Camera)

### DIFF
--- a/app/src/androidTest/java/com/android/feedme/test/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/UserFlowTest.kt
@@ -1,0 +1,97 @@
+package com.android.feedme.test
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import com.android.feedme.screen.CameraScreen
+import com.android.feedme.ui.CreateScreen
+import com.android.feedme.ui.LandingPage
+import com.android.feedme.ui.camera.CameraScreen
+import com.android.feedme.ui.navigation.NavigationActions
+import com.android.feedme.ui.navigation.Route
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UserFlowTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  // This rule automatic initializes lateinit properties with @MockK, @RelaxedMockK, etc.
+  @get:Rule val mockkRule = MockKRule(this)
+
+  // Relaxed mocks methods have a default implementation returning values
+  @RelaxedMockK lateinit var mockNavActions: NavigationActions
+
+  // Grant camera permission for tests
+  @get:Rule
+  val permissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
+
+  @Test
+  fun userFlowFromHomePageNavigatToCameraAndTakePhoto() {
+    // Set Navigation
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+
+      // Set up the navigation graph
+      NavHost(navController = navController, startDestination = Route.HOME) {
+        composable(Route.HOME) { LandingPage(navigationActions) }
+        composable(Route.CREATE) { CreateScreen(navigationActions) }
+        composable(Route.CAMERA) { CameraScreen(navigationActions) }
+      }
+    }
+
+    // From Home Page go to Camera
+    composeTestRule.onNodeWithText("Create").assertIsDisplayed().performClick()
+
+    // Open Camera
+    composeTestRule.onNodeWithTag("CameraButton").assertIsDisplayed().performClick()
+
+    // Take Photo
+    ComposeScreen.onComposeScreen<CameraScreen>(composeTestRule) {
+      cameraPreview { assertIsDisplayed() }
+
+      photoButton {
+        assertIsDisplayed()
+        performClick()
+      }
+
+      // Wait until the "Photo saved" text appears on the UI.
+      composeTestRule.waitUntil(timeoutMillis = 5000) {
+        try {
+          composeTestRule.onNodeWithText("Photo saved", useUnmergedTree = true).assertExists()
+          true // If assertExists() succeeds, return true to end waitUntil.
+        } catch (e: AssertionError) {
+          false // If the node isn't found, return false so waitUntil keeps trying.
+        }
+      }
+
+      galleryButton {
+        assertIsDisplayed()
+        performClick()
+      }
+
+      // Wait for the gallery to be displayed
+      composeTestRule.waitForIdle()
+
+      // Assert that the photos are displayed after clicking
+      composeTestRule
+          .onNodeWithContentDescription("Photo", useUnmergedTree = true)
+          .assertIsDisplayed()
+    }
+  }
+}

--- a/app/src/androidTest/java/com/android/feedme/test/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/UserFlowTest.kt
@@ -29,19 +29,13 @@ import org.junit.runner.RunWith
 class UserFlowTest : TestCase() {
   @get:Rule val composeTestRule = createComposeRule()
 
-  // This rule automatic initializes lateinit properties with @MockK, @RelaxedMockK, etc.
-  @get:Rule val mockkRule = MockKRule(this)
-
-  // Relaxed mocks methods have a default implementation returning values
-  @RelaxedMockK lateinit var mockNavActions: NavigationActions
-
   // Grant camera permission for tests
   @get:Rule
   val permissionRule: GrantPermissionRule =
       GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
 
   @Test
-  fun userFlowFromHomePageNavigatToCameraAndTakePhoto() {
+  fun userFlowFromHomePageNavigateToCameraAndTakePhoto() {
     // Set Navigation
     composeTestRule.setContent {
       val navController = rememberNavController()

--- a/app/src/androidTest/java/com/android/feedme/test/UserFlowTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/UserFlowTest.kt
@@ -19,8 +19,6 @@ import com.android.feedme.ui.navigation.NavigationActions
 import com.android.feedme.ui.navigation.Route
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import io.mockk.impl.annotations.RelaxedMockK
-import io.mockk.junit4.MockKRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
Automated test to test the following User Flow : As a user, I expect to effortlessly open the camera within the application and capture a clear picture of my receipt.
- Start Point: The test initiates from the home page of the application.
- Navigation: The test simulates the user's interaction and navigates to the create page and then on the camera page.
- Camera Activation: Upon reaching the page, the test verifies the successful activation of the camera module.
- Receipt Capture: The test emulates the user's action of capturing a picture of the receipt using the camera.
- End Point: The test concludes once the receipt picture is in the gallery.
