### PR TITLE
Profile Navigation Bug

### DIFF
--- a/app/src/main/java/com/android/feedme/model/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/android/feedme/model/viewmodel/ProfileViewModel.kt
@@ -184,6 +184,6 @@ class ProfileViewModel : ViewModel() {
     _viewingUserProfile.value = profile
     viewingUserId = profile.id
     fetchProfiles(profile.followers, _viewingUserFollowers)
-    fetchProfiles(profile.following, _currentUserFollowing)
+    fetchProfiles(profile.following, _viewingUserFollowing)
   }
 }


### PR DESCRIPTION
Found a bug from the PR : https://github.com/feedme-swent-epfl/feedme-android/pull/94
Found when implementing : https://github.com/feedme-swent-epfl/feedme-android/pull/95

Scenario : go to profile, navigate to one of your following, open their profile, look for their following.
Problem : will show the default profile.