### PR TITLE
Navigation from full recipe display AND RecipeCard to Profile

### DIFF
--- a/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
@@ -11,6 +11,7 @@ import com.android.feedme.model.data.Recipe
 import com.android.feedme.model.data.RecipeRepository
 import com.android.feedme.model.data.Step
 import com.android.feedme.model.viewmodel.HomeViewModel
+import com.android.feedme.model.viewmodel.ProfileViewModel
 import com.android.feedme.model.viewmodel.RecipeViewModel
 import com.android.feedme.screen.LandingScreen
 import com.android.feedme.ui.home.LandingPage
@@ -127,7 +128,11 @@ class LandingTest : TestCase() {
     }
     landingViewModel.setShowedRecipes(!fetchRecipes)
     composeTestRule.setContent {
-      LandingPage(mockk<NavigationActions>(relaxed = true), RecipeViewModel(), landingViewModel)
+      LandingPage(
+          mockk<NavigationActions>(relaxed = true),
+          RecipeViewModel(),
+          landingViewModel,
+          ProfileViewModel())
     }
     composeTestRule.waitForIdle()
   }

--- a/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
@@ -1,6 +1,8 @@
 package com.android.feedme.test
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.feedme.model.data.Ingredient
 import com.android.feedme.model.data.IngredientMetaData
@@ -139,11 +141,12 @@ class LandingTest : TestCase() {
         performClick()
       }
       composeTestRule.waitForIdle()
-      // composeTestRule.onNodeWithContentDescription("Search Icon Button").performClick()
+      composeTestRule.onNodeWithContentDescription("Search Icon Button").performClick()
+      composeTestRule.waitForIdle()
     }
   }
 
-  private fun goToLandingScreen(fetchRecipes: Boolean = true) {
+  private fun goToLandingScreen() {
     profileViewModel.setViewingProfile(Profile(id = "ID_DEFAULT_1"))
     val landingViewModel = HomeViewModel()
     landingViewModel.setRecipes(listOf(recipe, recipe, recipe))

--- a/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/LandingTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.feedme.model.data.Ingredient
 import com.android.feedme.model.data.IngredientMetaData
 import com.android.feedme.model.data.MeasureUnit
+import com.android.feedme.model.data.Profile
 import com.android.feedme.model.data.ProfileRepository
 import com.android.feedme.model.data.Recipe
 import com.android.feedme.model.data.RecipeRepository
@@ -16,9 +17,14 @@ import com.android.feedme.model.viewmodel.RecipeViewModel
 import com.android.feedme.screen.LandingScreen
 import com.android.feedme.ui.home.LandingPage
 import com.android.feedme.ui.navigation.NavigationActions
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
@@ -29,6 +35,12 @@ import org.junit.runner.RunWith
 class LandingTest : TestCase() {
   @get:Rule val composeTestRule = createComposeRule()
   private val mockFirestore = mockk<FirebaseFirestore>(relaxed = true)
+  private val mockDocumentReference = mockk<DocumentReference>(relaxed = true)
+  private val mockCollectionReference = mockk<CollectionReference>(relaxed = true)
+  private var mockDocumentSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+
+  private lateinit var profileRepository: ProfileRepository
+  private lateinit var profileViewModel: ProfileViewModel
 
   private val recipe =
       Recipe(
@@ -53,7 +65,7 @@ class LandingTest : TestCase() {
           tags = listOf("Meat"),
           time = 45.0,
           rating = 4.5,
-          userid = "username",
+          userid = "9vu1XpyZwrW5hSvEpHuuvcVVgiv2",
           difficulty = "Intermediate",
           "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.mamablip.com%2Fstorage%2FLasagna%2520with%2520Meat%2520and%2520Tomato%2520Sauce_3481612355355.jpg&f=1&nofb=1&ipt=8e887ba99ce20a85fb867dabbe0206c1146ebf2f13548b5653a2778e3ea18c54&ipo=images")
 
@@ -61,6 +73,19 @@ class LandingTest : TestCase() {
   fun init() {
     RecipeRepository.initialize(mockFirestore)
     ProfileRepository.initialize(mockFirestore)
+
+    ProfileRepository.initialize(mockFirestore)
+    profileRepository = ProfileRepository.instance
+
+    every { mockFirestore.collection("profiles") } returns mockCollectionReference
+    every { mockCollectionReference.document(any()) } returns mockDocumentReference
+
+    every { mockDocumentReference.get() } returns Tasks.forResult(mockDocumentSnapshot)
+    every { mockDocumentSnapshot.toObject(Profile::class.java) } returns
+        Profile(id = "ID_DEFAULT_1")
+
+    every { mockDocumentReference.set(any()) } returns Tasks.forResult(null)
+    profileViewModel = ProfileViewModel()
   }
 
   @Test
@@ -119,6 +144,7 @@ class LandingTest : TestCase() {
   }
 
   private fun goToLandingScreen(fetchRecipes: Boolean = true) {
+    profileViewModel.setViewingProfile(Profile(id = "ID_DEFAULT_1"))
     val landingViewModel = HomeViewModel()
     if (fetchRecipes) {
       landingViewModel.setRecipes(listOf(recipe, recipe, recipe))
@@ -132,7 +158,7 @@ class LandingTest : TestCase() {
           mockk<NavigationActions>(relaxed = true),
           RecipeViewModel(),
           landingViewModel,
-          ProfileViewModel())
+          profileViewModel)
     }
     composeTestRule.waitForIdle()
   }

--- a/app/src/androidTest/java/com/android/feedme/test/ui/FullRecipeTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/ui/FullRecipeTest.kt
@@ -9,9 +9,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.feedme.model.data.Ingredient
 import com.android.feedme.model.data.IngredientMetaData
 import com.android.feedme.model.data.MeasureUnit
+import com.android.feedme.model.data.Profile
+import com.android.feedme.model.data.ProfileRepository
 import com.android.feedme.model.data.Recipe
 import com.android.feedme.model.data.RecipeRepository
 import com.android.feedme.model.data.Step
+import com.android.feedme.model.viewmodel.ProfileViewModel
 import com.android.feedme.model.viewmodel.RecipeViewModel
 import com.android.feedme.ui.component.RecipeFullDisplay
 import com.android.feedme.ui.navigation.NavigationActions
@@ -54,7 +57,7 @@ class FullRecipeTest : TestCase() {
           tags = listOf("Meat"),
           time = 1.15,
           rating = 4.5,
-          userid = "@PasDavid",
+          userid = "9vu1XpyZwrW5hSvEpHuuvcVVgiv2",
           difficulty = "Intermediate",
           "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.mamablip.com%2Fstorage%2FLasagna%2520with%2520Meat%2520and%2520Tomato%2520Sauce_3481612355355.jpg&f=1&nofb=1&ipt=8e887ba99ce20a85fb867dabbe0206c1146ebf2f13548b5653a2778e3ea18c54&ipo=images")
 
@@ -69,26 +72,36 @@ class FullRecipeTest : TestCase() {
 
   // Avoid re-creating a viewModel for every test
   private lateinit var recipeViewModel: RecipeViewModel
+  private lateinit var profileViewModel: ProfileViewModel
+
   private lateinit var recipeRepository: RecipeRepository
+  private lateinit var profileRepository: ProfileRepository
 
   @Before
   fun setUpMocks() {
     every { mockNavActions.canGoBack() } returns true
 
     RecipeRepository.initialize(mockFirestore)
+    ProfileRepository.initialize(mockFirestore)
     recipeRepository = RecipeRepository.instance
+    profileRepository = ProfileRepository.instance
 
     every { mockFirestore.collection("recipes") } returns mockCollectionReference
-    every { mockCollectionReference.document("lasagna1") } returns mockDocumentReference
+    every { mockFirestore.collection("profiles") } returns mockCollectionReference
+    every { mockCollectionReference.document(any()) } returns mockDocumentReference
 
     every { mockDocumentReference.get() } returns Tasks.forResult(mockDocumentSnapshot)
     every { mockDocumentSnapshot.toObject(Recipe::class.java) } returns recipe
+    every { mockDocumentSnapshot.toObject(Profile::class.java) } returns
+        Profile(id = "ID_DEFAULT_1")
 
     every { mockDocumentReference.set(any()) } returns Tasks.forResult(null)
 
     recipeViewModel = RecipeViewModel()
     recipeViewModel.setRecipe(recipe)
     recipeViewModel.selectRecipe(recipe)
+
+    profileViewModel = ProfileViewModel()
   }
 
   @Test
@@ -120,7 +133,10 @@ class FullRecipeTest : TestCase() {
   }
 
   private fun goToFullRecipeScreen() {
-    composeTestRule.setContent { RecipeFullDisplay(Route.HOME, mockNavActions, recipeViewModel) }
+    profileViewModel.setViewingProfile(Profile(id = "ID_DEFAULT_1"))
+    composeTestRule.setContent {
+      RecipeFullDisplay(Route.HOME, mockNavActions, recipeViewModel, profileViewModel)
+    }
     composeTestRule.waitForIdle()
   }
 }

--- a/app/src/androidTest/java/com/android/feedme/test/ui/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/ui/SearchScreenTest.kt
@@ -17,8 +17,13 @@ import com.android.feedme.screen.SearchScreen
 import com.android.feedme.ui.home.SearchScreen
 import com.android.feedme.ui.navigation.NavigationActions
 import com.android.feedme.ui.navigation.Route
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase
 import org.junit.Before
@@ -30,6 +35,9 @@ import org.junit.runner.RunWith
 class SearchScreenTest : TestCase() {
   @get:Rule val composeTestRule = createComposeRule()
   private val mockFirestore = mockk<FirebaseFirestore>(relaxed = true)
+  private val mockDocumentReference = mockk<DocumentReference>(relaxed = true)
+  private val mockCollectionReference = mockk<CollectionReference>(relaxed = true)
+  private var mockDocumentSnapshot = mockk<DocumentSnapshot>(relaxed = true)
 
   private lateinit var searchViewModel: SearchViewModel
   private lateinit var profileViewModel: ProfileViewModel
@@ -71,6 +79,15 @@ class SearchScreenTest : TestCase() {
     ProfileRepository.initialize(mockFirestore)
     recipeRepository = RecipeRepository.instance
     profileRepository = ProfileRepository.instance
+
+    every { mockFirestore.collection("profiles") } returns mockCollectionReference
+    every { mockCollectionReference.document(any()) } returns mockDocumentReference
+
+    every { mockDocumentReference.get() } returns Tasks.forResult(mockDocumentSnapshot)
+    every { mockDocumentSnapshot.toObject(Profile::class.java) } returns
+        Profile(id = "ID_DEFAULT_1")
+
+    every { mockDocumentReference.set(any()) } returns Tasks.forResult(null)
 
     searchViewModel = SearchViewModel()
     profileViewModel = ProfileViewModel()

--- a/app/src/main/java/com/android/feedme/MainActivity.kt
+++ b/app/src/main/java/com/android/feedme/MainActivity.kt
@@ -86,7 +86,12 @@ class MainActivity : ComponentActivity() {
                     // Create a shared view model for Recipe
                     val recipeViewModel = viewModel<RecipeViewModel>()
                     val homeViewModel: HomeViewModel = viewModel<HomeViewModel>()
-                    LandingPage(navigationActions, recipeViewModel, homeViewModel, profileViewModel, searchViewModel)
+                    LandingPage(
+                        navigationActions,
+                        recipeViewModel,
+                        homeViewModel,
+                        profileViewModel,
+                        searchViewModel)
                   }
                 }
 

--- a/app/src/main/java/com/android/feedme/MainActivity.kt
+++ b/app/src/main/java/com/android/feedme/MainActivity.kt
@@ -132,7 +132,7 @@ class MainActivity : ComponentActivity() {
                     // Link the shared view model to the composable
                     val navBackStackEntry = navController.getBackStackEntry(backScreen)
                     val recipeViewModel = viewModel<RecipeViewModel>(navBackStackEntry)
-                    RecipeFullDisplay(it, navigationActions, recipeViewModel)
+                    RecipeFullDisplay(it, navigationActions, recipeViewModel, profileViewModel)
                   }
                 }
               }

--- a/app/src/main/java/com/android/feedme/MainActivity.kt
+++ b/app/src/main/java/com/android/feedme/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : ComponentActivity() {
                     // Create a shared view model for Recipe
                     val recipeViewModel = viewModel<RecipeViewModel>()
                     val homeViewModel: HomeViewModel = viewModel<HomeViewModel>()
-                    LandingPage(navigationActions, recipeViewModel, homeViewModel)
+                    LandingPage(navigationActions, recipeViewModel, homeViewModel, profileViewModel)
                   }
                 }
 

--- a/app/src/main/java/com/android/feedme/resources/DummyVals.kt
+++ b/app/src/main/java/com/android/feedme/resources/DummyVals.kt
@@ -29,6 +29,6 @@ val recipe =
         tags = listOf("Meat"),
         time = 45.0,
         rating = 4.5,
-        userid = "username",
+        userid = "9vu1XpyZwrW5hSvEpHuuvcVVgiv2",
         difficulty = "Intermediate",
         "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.mamablip.com%2Fstorage%2FLasagna%2520with%2520Meat%2520and%2520Tomato%2520Sauce_3481612355355.jpg&f=1&nofb=1&ipt=8e887ba99ce20a85fb867dabbe0206c1146ebf2f13548b5653a2778e3ea18c54&ipo=images")

--- a/app/src/main/java/com/android/feedme/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/home/LandingScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.android.feedme.model.data.Profile
 import com.android.feedme.model.data.Recipe
 import com.android.feedme.model.viewmodel.HomeViewModel
 import com.android.feedme.model.viewmodel.ProfileViewModel
@@ -77,7 +77,7 @@ fun LandingPage(
     navigationActions: NavigationActions,
     recipeViewModel: RecipeViewModel,
     homeViewModel: HomeViewModel,
-    profileViewModel: ProfileViewModel
+    profileViewModel: ProfileViewModel,
     searchViewModel: SearchViewModel
 ) {
 
@@ -91,7 +91,12 @@ fun LandingPage(
       },
       content = {
         RecipeDisplay(
-            it, navigationActions, recipes.value, searchViewModel, recipeViewModel, profileViewModel)
+            it,
+            navigationActions,
+            recipes.value,
+            searchViewModel,
+            recipeViewModel,
+            profileViewModel)
       })
 }
 
@@ -133,7 +138,7 @@ fun RecipeDisplay(
                 val profile = profileViewModel.viewingUserProfile.collectAsState().value
 
                 // Recipe card
-                RecipeCard(recipe, navigationActions, recipeViewModel)
+                RecipeCard(recipe, profile, navigationActions, recipeViewModel, profileViewModel)
               }
             }
       }
@@ -143,14 +148,18 @@ fun RecipeDisplay(
  * Composable function for the Recipe Card. This function displays the recipe in a card format.
  *
  * @param recipe The [Recipe] to be displayed.
+ * @param profile The [Profile] of the user who created the recipe.
  * @param navigationActions The [NavigationActions] instance for handling back navigation.
  * @param recipeViewModel The [RecipeViewModel] instance of the recipe ViewModel.
+ * @param profileViewModel The [ProfileViewModel] instance of the profile ViewModel.
  */
 @Composable
 fun RecipeCard(
     recipe: Recipe,
+    profile: Profile?,
     navigationActions: NavigationActions,
-    recipeViewModel: RecipeViewModel
+    recipeViewModel: RecipeViewModel,
+    profileViewModel: ProfileViewModel
 ) {
   Card(
       modifier =
@@ -278,8 +287,7 @@ fun RecipeCard(
                             .testTag("UserName"),
                     text = "@${profile.username}",
                     color = BlueUsername,
-                    style =
-                        TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Medium))
+                    style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Medium))
               }
             }
       }

--- a/app/src/main/java/com/android/feedme/ui/home/SearchScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/home/SearchScreen.kt
@@ -160,7 +160,14 @@ fun FilteredContent(
   } else {
     LazyColumn(modifier = Modifier.fillMaxSize().testTag("FilteredList")) {
       when (mode) {
-        0 -> items(recipes) { recipe -> RecipeCard(recipe, navigationActions, recipeViewModel) }
+        0 ->
+            items(recipes) { recipe ->
+              // Fetch the profile of the user who created the recipe
+              // TODO: will to be replaced with a single call to fetch all profiles if possible
+              profileViewModel.fetchProfile(recipe.userid)
+              val profile = profileViewModel.viewingUserProfile.collectAsState().value
+              RecipeCard(recipe, profile, navigationActions, recipeViewModel, profileViewModel)
+            }
         1 ->
             items(profiles) { profile -> FriendsCard(profile, navigationActions, profileViewModel) }
       }

--- a/app/src/main/java/com/android/feedme/ui/profile/FriendsScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/profile/FriendsScreen.kt
@@ -169,8 +169,8 @@ fun FriendsList(
  * @param profile The profile data of the user to display.
  * @param navigationActions Provides navigation actions for handling user interactions with the
  *   navigation bar.
- *     @param profileViewModel The view model that provides the profile data.
- *     @param isFollowerList A boolean value that determines if the user is in the follower list.
+ * @param profileViewModel The view model that provides the profile data.
+ * @param isFollowerList A boolean value that determines if the user is in the follower list.
  */
 @Composable
 fun FriendsCard(


### PR DESCRIPTION
Adapted the username implementation and added navigation to the user's Profile.

If a Recipe does not have a user creator, or this user's id could not be fetched, the username Text won't be displayed, you can see below both possibilities.

![Screenshot 2024-05-11 233623](https://github.com/feedme-swent-epfl/feedme-android/assets/100317488/ca5311eb-5808-4b37-94f2-46d7f9ff7ba7)


![Screenshot 2024-05-11 232431](https://github.com/feedme-swent-epfl/feedme-android/assets/100317488/02e36d91-78c9-4e86-b100-a86707fc1a2e)


### Update: 
I noticed that the username is also visible from the RecipeCard in the Home Page AND Search Page, so I also added the navigation from both.
