### PR TITLE
Add Logic/Navigation to Create a comment

### DIFF
--- a/app/src/androidTest/java/com/android/feedme/test/component/CreateCommentTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/component/CreateCommentTest.kt
@@ -4,8 +4,17 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.feedme.model.data.CommentRepository
+import com.android.feedme.model.data.ProfileRepository
+import com.android.feedme.model.data.RecipeRepository
+import com.android.feedme.model.viewmodel.CommentViewModel
+import com.android.feedme.model.viewmodel.ProfileViewModel
+import com.android.feedme.model.viewmodel.RecipeViewModel
 import com.android.feedme.ui.component.CreateComment
+import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.mockk
 import junit.framework.TestCase
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,9 +24,20 @@ class CreateCommentTest : TestCase() {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  private val mockFirestore = mockk<FirebaseFirestore>(relaxed = true)
+
+  @Before
+  fun init() {
+    RecipeRepository.initialize(mockFirestore)
+    ProfileRepository.initialize(mockFirestore)
+    CommentRepository.initialize(mockFirestore)
+  }
+
   @Test
   fun testCreateCommentEverythingDisplayed() {
-    composeTestRule.setContent { CreateComment() }
+    composeTestRule.setContent {
+      CreateComment(ProfileViewModel(), RecipeViewModel(), CommentViewModel()) {}
+    }
 
     composeTestRule.onNodeWithTag("OuterBox").assertIsDisplayed()
     composeTestRule.onNodeWithTag("InnerCol").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/feedme/test/component/CreateCommentTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/component/CreateCommentTest.kt
@@ -3,6 +3,7 @@ package com.android.feedme.test.component
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.feedme.model.data.CommentRepository
 import com.android.feedme.model.data.ProfileRepository
@@ -35,8 +36,9 @@ class CreateCommentTest : TestCase() {
 
   @Test
   fun testCreateCommentEverythingDisplayed() {
+    var bol = false
     composeTestRule.setContent {
-      CreateComment(ProfileViewModel(), RecipeViewModel(), CommentViewModel()) {}
+      CreateComment(ProfileViewModel(), RecipeViewModel(), CommentViewModel()) { bol = true }
     }
 
     composeTestRule.onNodeWithTag("OuterBox").assertIsDisplayed()
@@ -48,5 +50,10 @@ class CreateCommentTest : TestCase() {
     composeTestRule.onNodeWithTag("DescriptionField").assertIsDisplayed()
     composeTestRule.onNodeWithTag("DeleteButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("PublishButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("PublishButton").performClick()
+    assertTrue(bol)
+    bol = false
+    composeTestRule.onNodeWithTag("DeleteButton").performClick()
+    assertTrue(bol)
   }
 }

--- a/app/src/androidTest/java/com/android/feedme/test/component/SmallCommentsTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/component/SmallCommentsTest.kt
@@ -24,7 +24,7 @@ class SmallCommentsTest {
             "@author",
             "@author",
             "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.mamablip.com%2Fstorage%2FLasagna%2520with%2520Meat%2520and%2520Tomato%2520Sauce_3481612355355.jpg&f=1&nofb=1&ipt=8e887ba99ce20a85fb867dabbe0206c1146ebf2f13548b5653a2778e3ea18c54&ipo=images",
-            3.5,
+            "AAAAAAAAAALLLLLLLLLLEEEEEEEDDDDDDDDD",
             1.15,
             "Was uncooked",
             "I respected instruction, but the result wasn't great",

--- a/app/src/androidTest/java/com/android/feedme/test/component/SmallCommentsTest.kt
+++ b/app/src/androidTest/java/com/android/feedme/test/component/SmallCommentsTest.kt
@@ -36,7 +36,7 @@ class SmallCommentsTest {
     composeTestRule.onNodeWithContentDescription("Recipe Image").assertIsDisplayed()
 
     // Author name
-    composeTestRule.onNodeWithText(comment1.authorId).assertIsDisplayed()
+    composeTestRule.onNodeWithText(comment1.commentId).assertIsDisplayed()
 
     // Title
     composeTestRule.onNodeWithText(comment1.title).assertIsDisplayed()

--- a/app/src/main/java/com/android/feedme/MainActivity.kt
+++ b/app/src/main/java/com/android/feedme/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
+import com.android.feedme.model.data.CommentRepository
 import com.android.feedme.model.data.ProfileRepository
 import com.android.feedme.model.data.RecipeRepository
 import com.android.feedme.model.viewmodel.AuthViewModel
@@ -53,6 +54,7 @@ class MainActivity : ComponentActivity() {
     val firebase = FirebaseFirestore.getInstance()
     ProfileRepository.initialize(firebase)
     RecipeRepository.initialize(firebase)
+    CommentRepository.initialize(firebase)
     setContent {
       feedmeAppTheme {
         // A surface container using the 'background' color from the theme

--- a/app/src/main/java/com/android/feedme/model/data/Comment.kt
+++ b/app/src/main/java/com/android/feedme/model/data/Comment.kt
@@ -3,7 +3,7 @@ package com.android.feedme.model.data
 import java.util.Date
 
 data class Comment(
-    val commentId: String,
+    var commentId: String,
     val userId: String,
     val recipeId: String,
     val photoURL: String,

--- a/app/src/main/java/com/android/feedme/model/data/Comment.kt
+++ b/app/src/main/java/com/android/feedme/model/data/Comment.kt
@@ -3,11 +3,11 @@ package com.android.feedme.model.data
 import java.util.Date
 
 data class Comment(
-    val authorId: String,
+    val commentId: String,
+    val userId: String,
     val recipeId: String,
     val photoURL: String,
     val rating: Double,
-    val time: Double,
     val title: String,
     val content: String,
     val creationDate: Date

--- a/app/src/main/java/com/android/feedme/model/data/Comment.kt
+++ b/app/src/main/java/com/android/feedme/model/data/Comment.kt
@@ -3,7 +3,7 @@ package com.android.feedme.model.data
 import java.util.Date
 
 data class Comment(
-    var commentId: String,
+    var commentId: String = "DEFAULT_ID",
     val userId: String,
     val recipeId: String,
     val photoURL: String,

--- a/app/src/main/java/com/android/feedme/model/data/CommentRepository.kt
+++ b/app/src/main/java/com/android/feedme/model/data/CommentRepository.kt
@@ -37,7 +37,7 @@ class CommentRepository(private val db: FirebaseFirestore) {
    */
   fun addComment(comment: Comment, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     db.collection("comments")
-        .document(comment.authorId)
+        .document(comment.commentId)
         .set(comment)
         .addOnSuccessListener { onSuccess() }
         .addOnFailureListener { exception -> onFailure(exception) }

--- a/app/src/main/java/com/android/feedme/model/data/CommentRepository.kt
+++ b/app/src/main/java/com/android/feedme/model/data/CommentRepository.kt
@@ -29,21 +29,19 @@ class CommentRepository(private val db: FirebaseFirestore) {
   }
 
   /**
-   * Adds a comment to Firestore.
-   * Will OVERRIDE the comment Id and get a new from firestore.
+   * Adds a comment to Firestore. Will OVERRIDE the comment Id and get a new from firestore.
    *
    * @param comment The Comment object to be added.
    * @param onSuccess Callback invoked on successful addition of the comment.
    * @param onFailure Callback invoked on failure to add the comment, with an exception.
    */
   fun addComment(comment: Comment, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-      val newDocRef = db.collection("comments").document()
-      comment.commentId = newDocRef.id // Assign the generated ID to the comment
-      newDocRef.set(comment)
-          .addOnSuccessListener { onSuccess() }
-          .addOnFailureListener { exception ->
-              onFailure(exception)
-          }
+    val newDocRef = db.collection("comments").document()
+    comment.commentId = newDocRef.id // Assign the generated ID to the comment
+    newDocRef
+        .set(comment)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { exception -> onFailure(exception) }
   }
 
   /**

--- a/app/src/main/java/com/android/feedme/model/data/CommentRepository.kt
+++ b/app/src/main/java/com/android/feedme/model/data/CommentRepository.kt
@@ -30,17 +30,20 @@ class CommentRepository(private val db: FirebaseFirestore) {
 
   /**
    * Adds a comment to Firestore.
+   * Will OVERRIDE the comment Id and get a new from firestore.
    *
    * @param comment The Comment object to be added.
    * @param onSuccess Callback invoked on successful addition of the comment.
    * @param onFailure Callback invoked on failure to add the comment, with an exception.
    */
   fun addComment(comment: Comment, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    db.collection("comments")
-        .document(comment.commentId)
-        .set(comment)
-        .addOnSuccessListener { onSuccess() }
-        .addOnFailureListener { exception -> onFailure(exception) }
+      val newDocRef = db.collection("comments").document()
+      comment.commentId = newDocRef.id // Assign the generated ID to the comment
+      newDocRef.set(comment)
+          .addOnSuccessListener { onSuccess() }
+          .addOnFailureListener { exception ->
+              onFailure(exception)
+          }
   }
 
   /**

--- a/app/src/main/java/com/android/feedme/model/viewmodel/CommentViewModel.kt
+++ b/app/src/main/java/com/android/feedme/model/viewmodel/CommentViewModel.kt
@@ -30,38 +30,23 @@ class CommentViewModel : ViewModel() {
   }
 
   /**
-   * A function that sets the comment in the database
+   * A function that add a comment in the database Overwrites the comment object given to assign it
+   * a new commentId
    *
    * @param comment: the comment to set in the database
    */
-  fun setComment(comment: Comment) {
+  fun addComment(comment: Comment, onSuccess: () -> Unit) {
     viewModelScope.launch {
       repository.addComment(
           comment,
-          onSuccess = { _comment.value = comment },
+          onSuccess = {
+            _comment.value = comment
+            onSuccess()
+          },
           onFailure = {
             // Handle failure
             throw error("comment could not get updated")
           })
     }
   }
-
-    /**
-     * A function that sets the comment in the database
-     *
-     * @param comment: the comment to set in the database
-     */
-    fun addComment(comment: Comment,  onSuccess: () -> Unit ) {
-        viewModelScope.launch {
-            repository.addComment(
-                comment,
-                onSuccess = { _comment.value = comment
-                            onSuccess()
-                            },
-                onFailure = {
-                    // Handle failure
-                    throw error("comment could not get updated")
-                })
-        }
-    }
 }

--- a/app/src/main/java/com/android/feedme/model/viewmodel/CommentViewModel.kt
+++ b/app/src/main/java/com/android/feedme/model/viewmodel/CommentViewModel.kt
@@ -1,0 +1,48 @@
+package com.android.feedme.model.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.feedme.model.data.Comment
+import com.android.feedme.model.data.CommentRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * A class that generates the comment view model
+ *
+ * This class provides the link between the comment database and the rest of the code. It can be
+ * used in order to extract the comment information
+ */
+class CommentViewModel : ViewModel() {
+  private val repository = CommentRepository.instance
+  private val _comment = MutableStateFlow<Comment?>(null)
+
+  val comment: StateFlow<Comment?> = _comment
+
+  /**
+   * A function that selects a comment to be displayed
+   *
+   * @param comment: the comment to be displayed
+   */
+  fun selectComment(comment: Comment) {
+    _comment.value = comment
+  }
+
+  /**
+   * A function that sets the comment in the database
+   *
+   * @param comment: the comment to set in the database
+   */
+  fun setComment(comment: Comment) {
+    viewModelScope.launch {
+      repository.addComment(
+          comment,
+          onSuccess = { _comment.value = comment },
+          onFailure = {
+            // Handle failure
+            throw error("comment could not get updated")
+          })
+    }
+  }
+}

--- a/app/src/main/java/com/android/feedme/model/viewmodel/CommentViewModel.kt
+++ b/app/src/main/java/com/android/feedme/model/viewmodel/CommentViewModel.kt
@@ -45,4 +45,23 @@ class CommentViewModel : ViewModel() {
           })
     }
   }
+
+    /**
+     * A function that sets the comment in the database
+     *
+     * @param comment: the comment to set in the database
+     */
+    fun addComment(comment: Comment,  onSuccess: () -> Unit ) {
+        viewModelScope.launch {
+            repository.addComment(
+                comment,
+                onSuccess = { _comment.value = comment
+                            onSuccess()
+                            },
+                onFailure = {
+                    // Handle failure
+                    throw error("comment could not get updated")
+                })
+        }
+    }
 }

--- a/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.feedme.model.data.Comment
+import com.android.feedme.model.data.Profile
 import com.android.feedme.model.viewmodel.CommentViewModel
 import com.android.feedme.model.viewmodel.ProfileViewModel
 import com.android.feedme.model.viewmodel.RecipeViewModel
@@ -162,17 +163,21 @@ fun CreateComment(
                     // publish button
                     OutlinedButton(
                         onClick = {
-                          val com =
-                              Comment(
-                                  "ID_DEFAULT",
-                                  profileViewModel.currentUserId!!,
-                                  recipeViewModel.recipe.value!!.recipeId,
-                                  "URL_DEFAULT",
-                                  rating.toDouble(),
-                                  commentTitle,
-                                  description,
-                                  java.util.Date())
-                          commentViewModel.setComment(com)
+                            val com = Comment(
+                                "ID_DEFAULT",
+                                profileViewModel.currentUserId!!,
+                                recipeViewModel.recipe.value!!.recipeId,
+                                "URL_DEFAULT",
+                                rating.toDouble(),
+                                commentTitle,
+                                description,
+                                java.util.Date()
+                                )
+                            commentViewModel.addComment(com) {
+                                // the rest profileViewModel.setProfile(Profile())
+
+                            }
+
                         },
                         colors = ButtonDefaults.buttonColors(Color.White),
                         modifier =

--- a/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
@@ -166,8 +166,8 @@ fun CreateComment(
                           val com =
                               Comment(
                                   "ID_DEFAULT",
-                                  profileViewModel.currentUserId!!,
-                                  recipeViewModel.recipe.value!!.recipeId,
+                                  profileViewModel.currentUserId ?: "ID_DEFAULT",
+                                  recipeViewModel.recipe.value?.recipeId ?: "ID_DEFAULT",
                                   "URL_DEFAULT",
                                   rating.toDoubleOrNull() ?: 0.0,
                                   commentTitle,
@@ -176,11 +176,8 @@ fun CreateComment(
                           if (commentTitle.isNotEmpty() &&
                               description.isNotEmpty() &&
                               rating.isNotEmpty()) {
-
                             commentViewModel.addComment(com) {
-                              // the rest profileViewModel.setProfile(Profile())
                               // Add the comment Id to profile and recipe locally and in the db
-
                             }
                           }
                           onDismiss()

--- a/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
@@ -35,15 +35,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.feedme.model.data.Comment
+import com.android.feedme.model.viewmodel.CommentViewModel
+import com.android.feedme.model.viewmodel.ProfileViewModel
+import com.android.feedme.model.viewmodel.RecipeViewModel
 import com.android.feedme.ui.theme.TemplateColor
 
 /** Composable function to enable comment creation */
-@Preview
 @Composable
-fun CreateComment() {
+fun CreateComment(
+    profileViewModel: ProfileViewModel,
+    recipeViewModel: RecipeViewModel,
+    commentViewModel: CommentViewModel
+) {
 
   var commentTitle by remember { mutableStateOf("") }
   var rating by remember { mutableStateOf("") }
@@ -155,7 +161,19 @@ fun CreateComment() {
 
                     // publish button
                     OutlinedButton(
-                        onClick = { /* TODO() implement publishing button functionality */},
+                        onClick = {
+                          val com =
+                              Comment(
+                                  "ID_DEFAULT",
+                                  profileViewModel.currentUserId!!,
+                                  recipeViewModel.recipe.value!!.recipeId,
+                                  "URL_DEFAULT",
+                                  rating.toDouble(),
+                                  commentTitle,
+                                  description,
+                                  java.util.Date())
+                          commentViewModel.setComment(com)
+                        },
                         colors = ButtonDefaults.buttonColors(Color.White),
                         modifier =
                             Modifier.width(150.dp)

--- a/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/CreateComment.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.feedme.model.data.Comment
-import com.android.feedme.model.data.Profile
 import com.android.feedme.model.viewmodel.CommentViewModel
 import com.android.feedme.model.viewmodel.ProfileViewModel
 import com.android.feedme.model.viewmodel.RecipeViewModel
@@ -49,7 +48,8 @@ import com.android.feedme.ui.theme.TemplateColor
 fun CreateComment(
     profileViewModel: ProfileViewModel,
     recipeViewModel: RecipeViewModel,
-    commentViewModel: CommentViewModel
+    commentViewModel: CommentViewModel,
+    onDismiss: () -> Unit
 ) {
 
   var commentTitle by remember { mutableStateOf("") }
@@ -143,7 +143,7 @@ fun CreateComment(
 
                     // delete button
                     OutlinedButton(
-                        onClick = { /* TODO() implement deleting button functionality */},
+                        onClick = { onDismiss() },
                         colors = ButtonDefaults.buttonColors(Color.White),
                         modifier =
                             Modifier.width(150.dp)
@@ -163,21 +163,27 @@ fun CreateComment(
                     // publish button
                     OutlinedButton(
                         onClick = {
-                            val com = Comment(
-                                "ID_DEFAULT",
-                                profileViewModel.currentUserId!!,
-                                recipeViewModel.recipe.value!!.recipeId,
-                                "URL_DEFAULT",
-                                rating.toDouble(),
-                                commentTitle,
-                                description,
-                                java.util.Date()
-                                )
+                          val com =
+                              Comment(
+                                  "ID_DEFAULT",
+                                  profileViewModel.currentUserId!!,
+                                  recipeViewModel.recipe.value!!.recipeId,
+                                  "URL_DEFAULT",
+                                  rating.toDoubleOrNull() ?: 0.0,
+                                  commentTitle,
+                                  description,
+                                  java.util.Date())
+                          if (commentTitle.isNotEmpty() &&
+                              description.isNotEmpty() &&
+                              rating.isNotEmpty()) {
+
                             commentViewModel.addComment(com) {
-                                // the rest profileViewModel.setProfile(Profile())
+                              // the rest profileViewModel.setProfile(Profile())
+                              // Add the comment Id to profile and recipe locally and in the db
 
                             }
-
+                          }
+                          onDismiss()
                         },
                         colors = ButtonDefaults.buttonColors(Color.White),
                         modifier =

--- a/app/src/main/java/com/android/feedme/ui/component/RecipeFullDisplay.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/RecipeFullDisplay.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material.icons.twotone.Bookmark
 import androidx.compose.material.icons.twotone.Star
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -24,8 +26,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -36,11 +40,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import coil.compose.AsyncImage
 import com.android.feedme.model.data.IngredientMetaData
 import com.android.feedme.model.data.Profile
 import com.android.feedme.model.data.Recipe
 import com.android.feedme.model.data.Step
+import com.android.feedme.model.viewmodel.CommentViewModel
 import com.android.feedme.model.viewmodel.ProfileViewModel
 import com.android.feedme.model.viewmodel.RecipeViewModel
 import com.android.feedme.ui.navigation.BottomNavigationMenu
@@ -75,7 +81,7 @@ fun RecipeFullDisplay(
   // Fetch the profile of the user who created the recipe
   recipe?.let { profileViewModel.fetchProfile(it.userid) }
   val profile = profileViewModel.viewingUserProfile.collectAsState().value
-
+  var showDialog by remember { mutableStateOf(false) }
   Scaffold(
       modifier = Modifier.fillMaxSize(),
       topBar = {
@@ -88,6 +94,11 @@ fun RecipeFullDisplay(
       bottomBar = {
         BottomNavigationMenu(route, navigationActions::navigateTo, TOP_LEVEL_DESTINATIONS)
       },
+      floatingActionButton = {
+        FloatingActionButton(
+            onClick = { showDialog = true },
+            content = { Icon(imageVector = Icons.Outlined.Add, contentDescription = "Add") })
+      },
       content = { padding ->
         if (recipe != null) {
           LazyColumn(modifier = Modifier.padding(padding)) {
@@ -97,6 +108,15 @@ fun RecipeFullDisplay(
             items(recipe.ingredients) { ingredient -> IngredientDisplay(ingredient = ingredient) }
             item { IngredientStepsDividerDisplay() }
             items(recipe.steps) { step -> StepDisplay(step = step) }
+          }
+        }
+        if (showDialog) {
+          Dialog(onDismissRequest = { showDialog = false }) {
+            CreateComment(
+                profileViewModel,
+                recipeViewModel,
+                CommentViewModel(),
+            )
           }
         }
       })

--- a/app/src/main/java/com/android/feedme/ui/component/RecipeFullDisplay.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/RecipeFullDisplay.kt
@@ -110,16 +110,17 @@ fun RecipeFullDisplay(
             items(recipe.steps) { step -> StepDisplay(step = step) }
           }
         }
-        if (showDialog) {
-          Dialog(onDismissRequest = { showDialog = false }) {
-            CreateComment(
-                profileViewModel,
-                recipeViewModel,
-                CommentViewModel(),
-            )
+          if (showDialog) {
+              Dialog(onDismissRequest = { showDialog = false }) {
+                  CreateComment(
+                      profileViewModel = profileViewModel,
+                      recipeViewModel = recipeViewModel,
+                      commentViewModel = CommentViewModel()
+                  )
+              }
           }
         }
-      })
+      )
 }
 /**
  * Displays the image associated with a recipe.

--- a/app/src/main/java/com/android/feedme/ui/component/RecipeFullDisplay.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/RecipeFullDisplay.kt
@@ -110,17 +110,16 @@ fun RecipeFullDisplay(
             items(recipe.steps) { step -> StepDisplay(step = step) }
           }
         }
-          if (showDialog) {
-              Dialog(onDismissRequest = { showDialog = false }) {
-                  CreateComment(
-                      profileViewModel = profileViewModel,
-                      recipeViewModel = recipeViewModel,
-                      commentViewModel = CommentViewModel()
-                  )
-              }
+        if (showDialog) {
+          Dialog(onDismissRequest = { showDialog = false }) {
+            CreateComment(
+                profileViewModel = profileViewModel,
+                recipeViewModel = recipeViewModel,
+                commentViewModel = CommentViewModel(),
+                onDismiss = { showDialog = false })
           }
         }
-      )
+      })
 }
 /**
  * Displays the image associated with a recipe.

--- a/app/src/main/java/com/android/feedme/ui/component/SmallCommentsDisplay.kt
+++ b/app/src/main/java/com/android/feedme/ui/component/SmallCommentsDisplay.kt
@@ -79,7 +79,7 @@ fun CommentCard(comment: Comment) {
 
                 // Comment authorId
                 Text(
-                    text = comment.authorId,
+                    text = comment.commentId,
                     style = MaterialTheme.typography.bodyMedium,
                     color = BlueUsername,
                     fontWeight = FontWeight.Bold)

--- a/app/src/test/java/com/android/feedme/model/CommentRepositoryTest.kt
+++ b/app/src/test/java/com/android/feedme/model/CommentRepositoryTest.kt
@@ -69,7 +69,7 @@ class CommentRepositoryTest {
             "Content",
             Date.from(Instant.now()))
     `when`(mockFirestore.collection("comments")).thenReturn(mockCollectionReference)
-    `when`(mockCollectionReference.document(comment.authorId)).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document(comment.commentId)).thenReturn(mockDocumentReference)
     `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
 
     // Execute

--- a/app/src/test/java/com/android/feedme/model/data/CommentTest.kt
+++ b/app/src/test/java/com/android/feedme/model/data/CommentTest.kt
@@ -12,11 +12,11 @@ class CommentTest {
     // Given
     val comment =
         Comment(
+            userId = "user123",
             commentId = "user123",
             recipeId = "recipe456",
             photoURL = "https://example.com/photo.jpg",
             rating = 4.5,
-            time = 120.0,
             title = "Delicious!",
             content = "This recipe is fantastic!",
             creationDate = Date.from(Instant.now()))

--- a/app/src/test/java/com/android/feedme/model/data/CommentTest.kt
+++ b/app/src/test/java/com/android/feedme/model/data/CommentTest.kt
@@ -12,7 +12,7 @@ class CommentTest {
     // Given
     val comment =
         Comment(
-            authorId = "user123",
+            commentId = "user123",
             recipeId = "recipe456",
             photoURL = "https://example.com/photo.jpg",
             rating = 4.5,
@@ -22,7 +22,7 @@ class CommentTest {
             creationDate = Date.from(Instant.now()))
 
     // Then
-    assertEquals("user123", comment.authorId)
+    assertEquals("user123", comment.commentId)
     assertEquals("recipe456", comment.recipeId)
     assertEquals("https://example.com/photo.jpg", comment.photoURL)
     assertEquals(4.5, comment.rating, 0.0)

--- a/app/src/test/java/com/android/feedme/ui/CommentViewModelTest.kt
+++ b/app/src/test/java/com/android/feedme/ui/CommentViewModelTest.kt
@@ -1,0 +1,111 @@
+package com.android.feedme.model.viewmodel
+
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.android.feedme.model.data.Comment
+import com.android.feedme.model.data.CommentRepository
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import java.time.Instant
+import java.util.*
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class CommentViewModelTest {
+
+  @Mock private lateinit var mockFirestore: FirebaseFirestore
+
+  @Mock private lateinit var mockDocumentReference: DocumentReference
+
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+
+  private lateinit var viewModel: CommentViewModel
+
+  @Before
+  fun setUp() {
+    // Initialize Mockito annotations
+    MockitoAnnotations.openMocks(this)
+
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+    }
+
+    // Initialize the repository with the mocked Firestore instance
+    CommentRepository.initialize(mockFirestore)
+    `when`(mockFirestore.collection("comments")).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.document(anyString())).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+    `when`(mockDocumentReference.id).thenReturn("testCommentId")
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null))
+
+    // Initialize the ViewModel
+    viewModel = CommentViewModel()
+  }
+
+  @Test
+  fun selectComment_setsComment() {
+    val comment = createTestComment()
+    viewModel.selectComment(comment)
+
+    val result = viewModel.comment.value
+    assertEquals(comment, result)
+  }
+
+  @Test
+  fun addComment_success() {
+    val comment = createTestComment()
+    comment.commentId = "ajjaha"
+
+    var bol = false
+    viewModel.addComment(comment) { bol = true }
+
+    // Ensure all asynchronous operations complete
+    shadowOf(Looper.getMainLooper()).idle()
+
+    val result = viewModel.comment.value
+    assertEquals(comment, result)
+    assertNotEquals(comment.commentId, "ajjaha")
+    assertTrue(bol)
+  }
+
+  @Test
+  fun addComment_withEmptyCommentId() {
+    val comment = createTestComment()
+    comment.commentId = ""
+
+    var bol = false
+    viewModel.addComment(comment) { bol = true }
+
+    // Ensure all asynchronous operations complete
+    shadowOf(Looper.getMainLooper()).idle()
+
+    val result = viewModel.comment.value
+    assertEquals(comment, result)
+    assertNotEquals(comment.commentId, "")
+    assertTrue(bol)
+  }
+
+  private fun createTestComment(): Comment {
+    return Comment(
+        "authorId",
+        "recipeId",
+        "photoURL",
+        "hehehe",
+        120.0,
+        "Title",
+        "Content",
+        Date.from(Instant.now()))
+  }
+}


### PR DESCRIPTION
## UI Update
- [x] Added Pop-up logic to view the CreateComment UI 
- [x] Show the CreareScreen upon the FBA clicked
- [x] Close the CreateScreen upon the "submit" or "cancel" button is clicked

## Action Create a comment
- [x] Set the comment in the database and get it corresponding ID
- [x] Add the submited comment to the database (/comments/commentsId)

## ViewModel Update
- [x] Create a comment View Model, utilize CommentRepository to set a comment to the database

## Warning
This PR does not implement the update of commentId list of profile and recipe. New back-end function are required for it, and will be done at a later date in #177 