### PR TITLE
Fix : title on one line and corrected save screen

### DIFF
--- a/app/src/main/java/com/android/feedme/ui/home/SavedRecipesScreen.kt
+++ b/app/src/main/java/com/android/feedme/ui/home/SavedRecipesScreen.kt
@@ -46,7 +46,7 @@ fun SavedRecipesScreen(
 ) {
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("SavedScreen"),
-      topBar = { TopBarNavigation(title = "FeedMe") },
+      topBar = { TopBarNavigation(title = "Saved Recipe") },
       bottomBar = {
         BottomNavigationMenu(Route.SAVED, navigationActions::navigateTo, TOP_LEVEL_DESTINATIONS)
       },

--- a/app/src/main/java/com/android/feedme/ui/navigation/TopBarNavigation.kt
+++ b/app/src/main/java/com/android/feedme/ui/navigation/TopBarNavigation.kt
@@ -77,9 +77,10 @@ fun TopBarNavigation(
               Text(
                   modifier = Modifier.testTag("TitleText").width(250.dp),
                   text = title,
-                  fontSize = 20.sp,
+                  fontSize = 22.sp,
                   fontWeight = FontWeight.Bold,
                   color = TextBarColor,
+                  maxLines = 1,
                   textAlign = TextAlign.Center)
 
               // RightIconBox


### PR DESCRIPTION
When the page title is more than one word, its displayed on two lines and not one.
Tasks :
- [x]    Modify the UI of the Top Bar component
- [x]     Verify that this change apply well to all pages of the app.

![331888159-b4482298-9958-40b5-9427-43b4dd117537](https://github.com/feedme-swent-epfl/feedme-android/assets/94188707/77487d67-0cb2-4aef-b341-67bae9d724d0)


Additionnaly, do this small UI fix :

- [x]   The top bar title for the saved recipe screen is "FeedMe" and should be "Saved Recipe".

